### PR TITLE
Properly handle season on the Home page

### DIFF
--- a/app/components/lists/hub_renderer.go
+++ b/app/components/lists/hub_renderer.go
@@ -16,6 +16,8 @@ func MetadataCard(meta *sources.Metadata, coverURL func(string) string, context,
 		return cards.NewMoviePoster(meta, coverURL(meta.Thumb), serverID), true
 	case "show":
 		return cards.NewShowPoster(meta, meta.ChildCount, coverURL(meta.Thumb), serverID), true
+	case "season":
+		return cards.NewSeasonPoster(meta, coverURL(meta.Thumb), serverID), true
 	case "episode":
 		return cards.NewEpisodePoster(meta, coverURL(meta.GrandparentThumb), serverID), true
 	default:


### PR DESCRIPTION
Properly handle the "season" type for the Home pages "Recently added" sections.

Fixes #25