### PR TITLE
Add Play/Continue button to show page

### DIFF
--- a/app/pages/show.go
+++ b/app/pages/show.go
@@ -44,8 +44,7 @@ func Show(appCtx *appctx.AppContext, serverID, ratingKey string) *router.Respons
 	}
 
 	// Find the next episode to play
-	var nextEpisode *sources.Metadata
-	nextEpisode = findNextEpisode(ctx, src, seasons)
+	nextEpisode := findNextEpisode(ctx, src, seasons)
 
 	body := VStack().Spacing(25).VMargin(20).HMargin(40)
 


### PR DESCRIPTION
Add a button to the Show page that directly allows to play or continue to watch the show.