### PR TITLE
Add Play/Continue button to season page

### DIFF
--- a/app/pages/season.go
+++ b/app/pages/season.go
@@ -4,12 +4,15 @@ import (
 	"fmt"
 	"log/slog"
 
+	"codeberg.org/dergs/tonearm/pkg/schwifty"
 	. "codeberg.org/dergs/tonearm/pkg/schwifty/syntax"
 	"codeberg.org/puregotk/puregotk/v4/gtk"
 	"github.com/0skillallluck/scanline/app/appctx"
 	"github.com/0skillallluck/scanline/app/components/cards"
+	"github.com/0skillallluck/scanline/app/components/player"
 	"github.com/0skillallluck/scanline/app/components/widgets"
 	"github.com/0skillallluck/scanline/app/router"
+	"github.com/0skillallluck/scanline/app/sources"
 	"github.com/0skillallluck/scanline/internal/gettext"
 )
 
@@ -36,7 +39,50 @@ func Season(appCtx *appctx.AppContext, serverID, ratingKey string) *router.Respo
 
 	body := VStack().Spacing(25).VMargin(20).HMargin(40)
 
+	// Find the next episode to play
+	nextEpisode := findNextSeasonEpisode(episodes)
+
 	// Hero section
+	var buildButtonRow func() schwifty.Box
+	if nextEpisode != nil && len(nextEpisode.Media) > 0 && len(nextEpisode.Media[0].Part) > 0 {
+		ep := nextEpisode
+		playLabel := gettext.Get("Play")
+		if meta.ViewedLeafCount > 0 && meta.ViewedLeafCount < meta.LeafCount {
+			if ep.ViewOffset > 0 {
+				playLabel = fmt.Sprintf("%s %s", gettext.Get("Continue"), widgets.FormatTimestamp(ep.ViewOffset))
+			} else {
+				playLabel = fmt.Sprintf("%s %s", gettext.Get("Continue"), widgets.FormatEpisodeLabel(ep.ParentIndex, ep.Index))
+			}
+		}
+		buildButtonRow = func() schwifty.Box {
+			return HStack().Spacing(10).
+				Append(
+					Button().
+						Child(
+							HStack(
+								Image().FromIconName("media-playback-start-symbolic"),
+								Label(playLabel),
+							).Spacing(6),
+						).
+						TooltipText(gettext.Get("Play this episode")).
+						WithCSSClass("suggested-action").
+						WithCSSClass("pill").
+						ConnectClicked(func(b gtk.Button) {
+							player.NewPlayer(player.PlayerParams{
+								Ctx:        appCtx.Ctx,
+								Title:      ep.Title,
+								PartKey:    ep.Media[0].Part[0].Key,
+								Window:     appCtx.Window,
+								RatingKey:  ep.RatingKey,
+								Media:      ep.Media,
+								Source:     src,
+								ViewOffset: ep.ViewOffset,
+							})
+						}),
+				)
+		}
+	}
+
 	heroContent := widgets.HeroContent(widgets.HeroContentParams{
 		Title:            meta.ParentTitle,
 		TitleActionName:  "win.route.show",
@@ -44,6 +90,7 @@ func Season(appCtx *appctx.AppContext, serverID, ratingKey string) *router.Respo
 		Subtitle:         meta.Title,
 		SubtitleClass:    "title-2 dimmed",
 		Badges:           []string{fmt.Sprint(meta.Year)},
+		BuildButtonRow:   buildButtonRow,
 	})
 
 	hero := widgets.HeroSection(
@@ -84,4 +131,22 @@ func Season(appCtx *appctx.AppContext, serverID, ratingKey string) *router.Respo
 			Child(Clamp().MaximumSize(1200).Child(body)).
 			Policy(gtk.PolicyNeverValue, gtk.PolicyAutomaticValue),
 	}
+}
+
+// findNextSeasonEpisode finds the next episode to play within a single season.
+// It returns the first in-progress or unwatched episode.
+// If all episodes are watched, it returns the first episode.
+func findNextSeasonEpisode(episodes []sources.Metadata) *sources.Metadata {
+	if len(episodes) == 0 {
+		return nil
+	}
+
+	for i := range episodes {
+		ep := &episodes[i]
+		if ep.ViewOffset > 0 || ep.ViewCount == 0 {
+			return ep
+		}
+	}
+
+	return &episodes[0]
 }


### PR DESCRIPTION
Add a button to the Season page that directly allows to play or continue to watch the season.

Similiar to the one we added to the Show page.