### PR TITLE
Fix navigation race condition

### DIFF
--- a/app/pages/cast.go
+++ b/app/pages/cast.go
@@ -1,6 +1,7 @@
 package pages
 
 import (
+	"context"
 	"log/slog"
 	"strconv"
 
@@ -19,14 +20,12 @@ import (
 
 var CastRoute = router.NewRoute("cast/:server/:tagId", Cast)
 
-func Cast(appCtx *appctx.AppContext, serverID, tagID string) *router.Response {
+func Cast(ctx context.Context, appCtx *appctx.AppContext, serverID, tagID string) *router.Response {
 	mgr := appCtx.Manager
 	src := mgr.SourceForServer(serverID)
 	if src == nil {
 		return router.FromError(gettext.Get("Cast"), errSourceNotFound(serverID))
 	}
-
-	ctx := appCtx.Ctx
 
 	sections, err := src.LibrarySections(ctx)
 	if err != nil {

--- a/app/pages/episode.go
+++ b/app/pages/episode.go
@@ -1,6 +1,7 @@
 package pages
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"strconv"
@@ -20,14 +21,12 @@ import (
 
 var EpisodeRoute = router.NewRoute("episode/:server/:ratingKey", Episode)
 
-func Episode(appCtx *appctx.AppContext, serverID, ratingKey string) *router.Response {
+func Episode(ctx context.Context, appCtx *appctx.AppContext, serverID, ratingKey string) *router.Response {
 	mgr := appCtx.Manager
 	src := mgr.SourceForServer(serverID)
 	if src == nil {
 		return router.FromError(gettext.Get("Episode"), errSourceNotFound(serverID))
 	}
-
-	ctx := appCtx.Ctx
 
 	meta, err := src.GetMetadata(ctx, ratingKey)
 	if err != nil {
@@ -78,7 +77,7 @@ func Episode(appCtx *appctx.AppContext, serverID, ratingKey string) *router.Resp
 						ConnectClicked(func(b gtk.Button) {
 							if len(meta.Media) > 0 && len(meta.Media[0].Part) > 0 {
 								player.NewPlayer(player.PlayerParams{
-									Ctx:        appCtx.Ctx,
+									Ctx:        ctx,
 									Title:      meta.Title,
 									PartKey:    meta.Media[0].Part[0].Key,
 									Window:     appCtx.Window,
@@ -106,9 +105,9 @@ func Episode(appCtx *appctx.AppContext, serverID, ratingKey string) *router.Resp
 							go func() {
 								var err error
 								if watched {
-									err = src.Unscrobble(appCtx.Ctx, ratingKey)
+									err = src.Unscrobble(ctx, ratingKey)
 								} else {
-									err = src.Scrobble(appCtx.Ctx, ratingKey)
+									err = src.Scrobble(ctx, ratingKey)
 								}
 								if err != nil {
 									slog.Error("failed to update watch status", "ratingKey", ratingKey, "error", err)

--- a/app/pages/genre.go
+++ b/app/pages/genre.go
@@ -1,6 +1,7 @@
 package pages
 
 import (
+	"context"
 	"log/slog"
 	"strconv"
 
@@ -17,14 +18,12 @@ import (
 
 var GenreRoute = router.NewRoute("genre/:server/:genreId", Genre)
 
-func Genre(appCtx *appctx.AppContext, serverID, genreID string) *router.Response {
+func Genre(ctx context.Context, appCtx *appctx.AppContext, serverID, genreID string) *router.Response {
 	mgr := appCtx.Manager
 	src := mgr.SourceForServer(serverID)
 	if src == nil {
 		return router.FromError(gettext.Get("Genre"), errSourceNotFound(serverID))
 	}
-
-	ctx := appCtx.Ctx
 
 	sections, err := src.LibrarySections(ctx)
 	if err != nil {

--- a/app/pages/home.go
+++ b/app/pages/home.go
@@ -1,6 +1,7 @@
 package pages
 
 import (
+	"context"
 	"log/slog"
 
 	. "codeberg.org/dergs/tonearm/pkg/schwifty/syntax"
@@ -15,13 +16,13 @@ import (
 
 var HomeRoute = router.NewRoute("home", home)
 
-func home(appCtx *appctx.AppContext) *router.Response {
+func home(ctx context.Context, appCtx *appctx.AppContext) *router.Response {
 	mgr := appCtx.Manager
 
 	body := VStack().Spacing(25).VMargin(20)
 
 	for _, src := range mgr.EnabledSources() {
-		hubList, err := src.HomeHubs(appCtx.Ctx, 24)
+		hubList, err := src.HomeHubs(ctx, 24)
 		if err != nil {
 			slog.Error("failed to fetch home hubs", "source", src.Name(), "error", err)
 			continue

--- a/app/pages/library.go
+++ b/app/pages/library.go
@@ -1,6 +1,8 @@
 package pages
 
 import (
+	"context"
+
 	. "codeberg.org/dergs/tonearm/pkg/schwifty/syntax"
 	"codeberg.org/puregotk/puregotk/v4/adw"
 	"codeberg.org/puregotk/puregotk/v4/gtk"
@@ -13,14 +15,12 @@ import (
 
 var LibraryRoute = router.NewRoute("library/:server/:id", Library)
 
-func Library(appCtx *appctx.AppContext, serverID, sectionID string) *router.Response {
+func Library(ctx context.Context, appCtx *appctx.AppContext, serverID, sectionID string) *router.Response {
 	mgr := appCtx.Manager
 	src := mgr.SourceForServer(serverID)
 	if src == nil {
 		return router.FromError(gettext.Get("Library"), errSourceNotFound(serverID))
 	}
-
-	ctx := appCtx.Ctx
 
 	section, err := src.LibrarySection(ctx, sectionID)
 	if err != nil {

--- a/app/pages/movie.go
+++ b/app/pages/movie.go
@@ -1,6 +1,7 @@
 package pages
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"strconv"
@@ -22,14 +23,12 @@ import (
 
 var MovieRoute = router.NewRoute("movie/:server/:ratingKey", Movie)
 
-func Movie(appCtx *appctx.AppContext, serverID, ratingKey string) *router.Response {
+func Movie(ctx context.Context, appCtx *appctx.AppContext, serverID, ratingKey string) *router.Response {
 	mgr := appCtx.Manager
 	src := mgr.SourceForServer(serverID)
 	if src == nil {
 		return router.FromError(gettext.Get("Movie"), errSourceNotFound(serverID))
 	}
-
-	ctx := appCtx.Ctx
 
 	meta, err := src.GetMetadata(ctx, ratingKey)
 	if err != nil {
@@ -89,7 +88,7 @@ func Movie(appCtx *appctx.AppContext, serverID, ratingKey string) *router.Respon
 						ConnectClicked(func(b gtk.Button) {
 							if len(meta.Media) > 0 && len(meta.Media[0].Part) > 0 {
 								player.NewPlayer(player.PlayerParams{
-									Ctx:        appCtx.Ctx,
+									Ctx:        ctx,
 									Title:      meta.Title,
 									PartKey:    meta.Media[0].Part[0].Key,
 									Window:     appCtx.Window,
@@ -117,9 +116,9 @@ func Movie(appCtx *appctx.AppContext, serverID, ratingKey string) *router.Respon
 							go func() {
 								var err error
 								if watched {
-									err = src.Unscrobble(appCtx.Ctx, ratingKey)
+									err = src.Unscrobble(ctx, ratingKey)
 								} else {
-									err = src.Scrobble(appCtx.Ctx, ratingKey)
+									err = src.Scrobble(ctx, ratingKey)
 								}
 								if err != nil {
 									slog.Error("failed to update watch status", "ratingKey", ratingKey, "error", err)

--- a/app/pages/search.go
+++ b/app/pages/search.go
@@ -1,6 +1,7 @@
 package pages
 
 import (
+	"context"
 	"log/slog"
 	"time"
 
@@ -29,7 +30,7 @@ type cachedSource struct {
 	serverID string
 }
 
-var SearchRoute = router.NewRoute("search", func(appCtx *appctx.AppContext) *router.Response {
+var SearchRoute = router.NewRoute("search", func(ctx context.Context, appCtx *appctx.AppContext) *router.Response {
 	scrollChildState := state.NewStateful[any](search.PromptView())
 	searchState := state.NewStateful(false)
 	var cached []cachedSource
@@ -68,7 +69,7 @@ var SearchRoute = router.NewRoute("search", func(appCtx *appctx.AppContext) *rou
 			var newCached []cachedSource
 
 			for _, src := range mgr.EnabledSources() {
-				hubs, err := src.Search(appCtx.Ctx, query, 50)
+				hubs, err := src.Search(ctx, query, 50)
 				if err != nil {
 					slog.Error("search failed", "source", src.Name(), "error", err)
 					continue

--- a/app/pages/season.go
+++ b/app/pages/season.go
@@ -1,6 +1,7 @@
 package pages
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 
@@ -18,14 +19,12 @@ import (
 
 var SeasonRoute = router.NewRoute("season/:server/:ratingKey", Season)
 
-func Season(appCtx *appctx.AppContext, serverID, ratingKey string) *router.Response {
+func Season(ctx context.Context, appCtx *appctx.AppContext, serverID, ratingKey string) *router.Response {
 	mgr := appCtx.Manager
 	src := mgr.SourceForServer(serverID)
 	if src == nil {
 		return router.FromError(gettext.Get("Season"), errSourceNotFound(serverID))
 	}
-
-	ctx := appCtx.Ctx
 
 	meta, err := src.GetMetadata(ctx, ratingKey)
 	if err != nil {
@@ -69,7 +68,7 @@ func Season(appCtx *appctx.AppContext, serverID, ratingKey string) *router.Respo
 						WithCSSClass("pill").
 						ConnectClicked(func(b gtk.Button) {
 							player.NewPlayer(player.PlayerParams{
-								Ctx:        appCtx.Ctx,
+								Ctx:        ctx,
 								Title:      ep.Title,
 								PartKey:    ep.Media[0].Part[0].Key,
 								Window:     appCtx.Window,

--- a/app/pages/show.go
+++ b/app/pages/show.go
@@ -21,14 +21,12 @@ import (
 
 var ShowRoute = router.NewRoute("show/:server/:ratingKey", Show)
 
-func Show(appCtx *appctx.AppContext, serverID, ratingKey string) *router.Response {
+func Show(ctx context.Context, appCtx *appctx.AppContext, serverID, ratingKey string) *router.Response {
 	mgr := appCtx.Manager
 	src := mgr.SourceForServer(serverID)
 	if src == nil {
 		return router.FromError(gettext.Get("TV Show"), errSourceNotFound(serverID))
 	}
-
-	ctx := appCtx.Ctx
 
 	meta, err := src.GetMetadata(ctx, ratingKey)
 	if err != nil {
@@ -76,7 +74,7 @@ func Show(appCtx *appctx.AppContext, serverID, ratingKey string) *router.Respons
 						WithCSSClass("pill").
 						ConnectClicked(func(b gtk.Button) {
 							player.NewPlayer(player.PlayerParams{
-								Ctx:        appCtx.Ctx,
+								Ctx:        ctx,
 								Title:      ep.Title,
 								PartKey:    ep.Media[0].Part[0].Key,
 								Window:     appCtx.Window,

--- a/app/router/routemap.go
+++ b/app/router/routemap.go
@@ -1,6 +1,7 @@
 package router
 
 import (
+	"context"
 	"reflect"
 	"regexp"
 )
@@ -11,10 +12,11 @@ var (
 	argReplaceRegex = regexp.MustCompile(`(:[^\/]+)`)
 )
 
-func findHandler(path string, appCtx any) func() *Response {
+func findHandler(path string, ctx context.Context, appCtx any) func() *Response {
 	for regex, handler := range newRouteMap {
 		if regex.MatchString(path) {
 			argMap := make([]reflect.Value, 0)
+			argMap = append(argMap, reflect.ValueOf(ctx))
 			if appCtx != nil {
 				argMap = append(argMap, reflect.ValueOf(appCtx))
 			}
@@ -40,12 +42,14 @@ func Register(path string, handler any) {
 	// Count expected path params
 	pathParamCount := len(argReplaceRegex.FindAllString(path, -1))
 
-	// Handler may have an appCtx first param (non-string) followed by string params
+	// Skip leading non-string params (context.Context, *appctx.AppContext, etc.)
 	numIn := handlerType.NumIn()
 	stringParamStart := 0
-	if numIn > 0 && handlerType.In(0).Kind() != reflect.String {
-		// First param is the context type, skip it for path param counting
-		stringParamStart = 1
+	for i := 0; i < numIn; i++ {
+		if handlerType.In(i).Kind() == reflect.String {
+			break
+		}
+		stringParamStart++
 	}
 
 	stringParamCount := numIn - stringParamStart

--- a/app/router/router.go
+++ b/app/router/router.go
@@ -14,10 +14,11 @@ var logger = slog.With("module", "router")
 
 // Router encapsulates navigation state, history, and signals.
 type Router struct {
-	history *History
-	appCtx  any
-	ctx     context.Context
-	wg      sync.WaitGroup
+	history   *History
+	appCtx    any
+	ctx       context.Context
+	navCancel context.CancelFunc
+	wg        sync.WaitGroup
 
 	NavigationStarted   *signals.StatelessSignal[string]
 	NavigationCompleted *signals.StatelessSignal[HistoryEntry]
@@ -67,17 +68,23 @@ func (r *Router) navigate(path string, offRecord bool) {
 		return
 	}
 
+	// Cancel any in-flight navigation so stale results don't race into the UI.
+	if r.navCancel != nil {
+		r.navCancel()
+	}
+	navCtx, navCancel := context.WithCancel(r.ctx)
+	r.navCancel = navCancel
+
 	logger.Debug("navigation started")
 	r.NavigationStarted.Notify(path)
 
-	handler := findHandler(path, r.appCtx)
+	handler := findHandler(path, navCtx, r.appCtx)
 	if handler == nil {
 		logger.Info("no handler found", "path", path)
 		handler = notFoundHandler
 	}
 
 	startTime := time.Now()
-	ctx := r.ctx
 	logger.Debug("executing route handler", "path", path, "started_at", startTime)
 	r.wg.Add(1)
 	go func(ctx context.Context, path string, handler Handler) {
@@ -102,7 +109,7 @@ func (r *Router) navigate(path string, offRecord bool) {
 			r.history.Push(entry, r.HistoryUpdated)
 		}
 		r.NavigationCompleted.Notify(*entry)
-	}(ctx, path, handler)
+	}(navCtx, path, handler)
 }
 
 func (r *Router) Back() {


### PR DESCRIPTION
When quickly navigating a slow navigation might finish after a new page has already navigated in causing the app to go back to the old navigation.

This is fixed by using a new context and canceling it when a new navigation is started.