### PR TITLE
Update Tonearm and puregotk to get latest libsecret changes

### DIFF
--- a/app/dialogs/about/about.go
+++ b/app/dialogs/about/about.go
@@ -132,7 +132,6 @@ func NewAboutDialog() *adw.AboutDialog {
 	dialog.AddLegalSection("UUID (google/uuid)", "© 2009, 2014 Google Inc. https://github.com/google/uuid", gtk.LicenseBsd3Value, "")
 	dialog.AddLegalSection("System Locale Detection (jeandeaual/go-locale)", "© 2020 Alexis Jeandeau https://github.com/jeandeaual/go-locale", gtk.LicenseMitX11Value, "")
 	dialog.AddLegalSection("GTK4 / Libadwaita Bindings (jwijenbergh/puregotk)", "© 2022 Kyle McGough https://codeberg.org/puregotk/puregotk", gtk.LicenseMitX11Value, "")
-	dialog.AddLegalSection("Libsecret (lescuer97/go-libsecret)", "© 2025 Leonardo Escuer https://github.com/lescuer97/go-libsecret", gtk.LicenseMitX11Value, "")
 	dialog.AddLegalSection("JSON Merger (qjebbs/go-jsons)", "© 2022 Jebbs https://github.com/qjebbs/go-jsons", gtk.LicenseMitX11Value, "")
 	dialog.AddLegalSection("ISO8601 Duration Parser (osodev/duration)", "© 2023 Jeroen Wijenbergh https://github.com/sosodev/duration", gtk.LicenseMitX11Value, "")
 	dialog.AddLegalSection("QR Code Generator (yeqown/go-qrcode)", "© 2018 yeqown https://github.com/yeqown/go-qrcode", gtk.LicenseMitX11Value, "")

--- a/app/secrets/service_linux.go
+++ b/app/secrets/service_linux.go
@@ -3,47 +3,27 @@
 package secrets
 
 import (
+	"errors"
 	"strings"
-	"sync"
 
 	"github.com/0skillallluck/scanline/internal/gettext"
-	golibsecret "github.com/lescuer97/go-libsecret"
+	"codeberg.org/puregotk/puregotk/v4/glib"
+	"codeberg.org/puregotk/puregotk/v4/secret"
 )
 
-var (
-	schemaOnce sync.Once
-	schema     *golibsecret.Schema
-	schemaErr  error
-)
-
-func getSchema() (*golibsecret.Schema, error) {
-	schemaOnce.Do(func() {
-		schema, schemaErr = golibsecret.NewSchema("dev.skillless.Scanline", golibsecret.SchemaFlagsNone, map[string]golibsecret.SchemaAttributeType{
-			"key": golibsecret.SchemaAttributeString,
-		})
-	})
-	return schema, schemaErr
-}
+var schema *secret.Schema = secret.NewSchema("dev.skillless.Scanline", secret.SchemaNoneValue, "key", secret.SchemaAttributeStringValue)
 
 type serviceLinux struct{}
 
 func (s *serviceLinux) Available() *ServiceError {
-	schema, err := getSchema()
-	if err != nil {
-		return &ServiceError{
-			Title: gettext.Get("Secret Service Error"),
-			Body:  gettext.Getf("An unknown error occurred when checking for a secret service provider.\n\nSigning in may or may not work. Please see the raw error message for more details:\n\n%s", err.Error()),
-			Fatal: false,
-		}
-	}
-
 	// Fake secret fetch to see if the service is available
-	attrs := golibsecret.NewAttributes()
-	attrs.Set("key", "dummy_key") //nolint:errcheck
-	_, err = golibsecret.PasswordLookupSync(schema, attrs)
+	var err *glib.Error
+	secret.PasswordLookupSync(schema, nil, &err, "key", "dummy_key")
+
 	if err == nil {
 		return nil
 	}
+	defer err.Free()
 
 	if strings.Contains(err.Error(), "name is not activatable") || strings.Contains(err.Error(), "ServiceUnknown") {
 		return &ServiceError{
@@ -69,28 +49,28 @@ func (s *serviceLinux) Available() *ServiceError {
 }
 
 func (s *serviceLinux) Delete(key string) error {
-	schema, err := getSchema()
+	var err *glib.Error
+	secret.PasswordClearSync(schema, nil, &err, "key", key)
 	if err != nil {
-		return err
+		defer err.Free()
+		return errors.New(err.Error())
 	}
-	_, err = golibsecret.ClearPassword(schema, map[string]string{
-		"key": key,
-	})
-	return err
+	return nil
 }
 
 func (s *serviceLinux) Get(key string) (Item, error) {
-	schema, err := getSchema()
+	var err *glib.Error
+	val := secret.PasswordLookupSync(schema, nil, &err, "key", key)
+
 	if err != nil {
-		return Item{}, err
+		defer err.Free()
+		return Item{}, errors.New(err.Error())
 	}
-	attrs := golibsecret.NewAttributes()
-	attrs.Set("key", key) //nolint:errcheck
-	val, err := golibsecret.PasswordLookupSync(schema, attrs)
-	if val == "" && err == nil {
+
+	if val == "" {
 		return Item{}, ErrKeyNotFound
 	}
-	return Item{Label: "", Password: val}, err
+	return Item{Label: "", Password: val}, nil
 }
 
 func (s *serviceLinux) Has(key string) (bool, error) {
@@ -106,13 +86,13 @@ func (s *serviceLinux) Has(key string) (bool, error) {
 }
 
 func (s *serviceLinux) Set(key string, value Item) error {
-	schema, err := getSchema()
+	var err *glib.Error
+	secret.PasswordStoreSync(schema, secret.COLLECTION_DEFAULT, value.Label, value.Password, nil, &err, "key", key)
 	if err != nil {
-		return err
+		defer err.Free()
+		return errors.New(err.Error())
 	}
-	attrs := golibsecret.NewAttributes()
-	attrs.Set("key", key) //nolint:errcheck
-	return golibsecret.PasswordStoreSync(schema, attrs, golibsecret.CollectionDefault, value.Label, value.Password)
+	return nil
 }
 
 func newService() Service {

--- a/assets/meta/go.mod.yml
+++ b/assets/meta/go.mod.yml
@@ -3,15 +3,15 @@
   path: assets/meta/modules.txt
   type: file
 - dest: vendor/codeberg.org/dergs/tonearm
-  sha256: dcb91873c7b49d7559dcaf0df9c3e86dee669839ded1d1a53193fca07c0983ac
+  sha256: 8fb29b284ef0b7dcc9761a646470c80651344553543cdddf1c1f1de00435c4b5
   strip-components: 3
   type: archive
-  url: https://proxy.golang.org/codeberg.org/dergs/tonearm/@v/v1.4.1-0.20260304095737-2bc41c208498.zip
+  url: https://proxy.golang.org/codeberg.org/dergs/tonearm/@v/v1.4.1-0.20260423094524-7e92b9bac909.zip
 - dest: vendor/codeberg.org/puregotk/puregotk
-  sha256: 9d9a3c7b34bd5a9b1556630adf8da2fc24c177ebbc3cce37fcaf3ada283e79ca
+  sha256: e7fded6b4e364e3f2926d9470a991de1e422a712849008a24c347b2ccd96b5cf
   strip-components: 3
   type: archive
-  url: https://proxy.golang.org/codeberg.org/puregotk/puregotk/@v/v0.0.0-20260320050432-5bb8c3359c53.zip
+  url: https://proxy.golang.org/codeberg.org/puregotk/puregotk/@v/v0.0.0-20260420231554-98419d54d2d2.zip
 - dest: vendor/github.com/google/uuid
   sha256: d0f02f377217f42702e259684e06441edbf5140dddcc34ba9bea56038b38a6ed
   strip-components: 3
@@ -32,11 +32,6 @@
   strip-components: 3
   type: archive
   url: https://proxy.golang.org/github.com/leonelquinteros/gotext/@v/v1.7.2.zip
-- dest: vendor/github.com/lescuer97/go-libsecret
-  sha256: 10a7fbab46f2c68a5ba5eb773c259aa13c8e3af842152ac5e27b559de6fc24f3
-  strip-components: 3
-  type: archive
-  url: https://proxy.golang.org/github.com/lescuer97/go-libsecret/@v/v0.0.0-20251130160347-067b741bcf5a.zip
 - dest: vendor/github.com/yeqown/go-qrcode/v2
   sha256: 6d6d8af4e03b8f69e76be64b793fb9715934eb215ca88feeaa79e20ae3b5c512
   strip-components: 4

--- a/assets/meta/modules.txt
+++ b/assets/meta/modules.txt
@@ -1,4 +1,4 @@
-# codeberg.org/dergs/tonearm v1.4.1-0.20260304095737-2bc41c208498
+# codeberg.org/dergs/tonearm v1.4.1-0.20260423094524-7e92b9bac909
 ## explicit; go 1.26.0
 codeberg.org/dergs/tonearm/internal/signals
 codeberg.org/dergs/tonearm/pkg/schwifty
@@ -18,8 +18,8 @@ codeberg.org/puregotk/purego/internal/cgo
 codeberg.org/puregotk/purego/internal/fakecgo
 codeberg.org/puregotk/purego/internal/strings
 codeberg.org/puregotk/purego/internal/xreflect
-# codeberg.org/puregotk/puregotk v0.0.0-20260320050432-5bb8c3359c53
-## explicit; go 1.23.0
+# codeberg.org/puregotk/puregotk v0.0.0-20260420231554-98419d54d2d2
+## explicit; go 1.24.0
 codeberg.org/puregotk/puregotk/internal/core
 codeberg.org/puregotk/puregotk/pkg/core
 codeberg.org/puregotk/puregotk/v4/adw
@@ -35,6 +35,7 @@ codeberg.org/puregotk/puregotk/v4/graphene
 codeberg.org/puregotk/puregotk/v4/gsk
 codeberg.org/puregotk/puregotk/v4/gtk
 codeberg.org/puregotk/puregotk/v4/pango
+codeberg.org/puregotk/puregotk/v4/secret
 # github.com/fogleman/gg v1.3.0
 ## explicit
 github.com/fogleman/gg
@@ -55,9 +56,6 @@ github.com/keybase/go-keychain
 ## explicit; go 1.23.5
 github.com/leonelquinteros/gotext
 github.com/leonelquinteros/gotext/plurals
-# github.com/lescuer97/go-libsecret v0.0.0-20251130160347-067b741bcf5a
-## explicit; go 1.25.4
-github.com/lescuer97/go-libsecret
 # github.com/pkg/errors v0.9.1
 ## explicit
 github.com/pkg/errors

--- a/flake.nix
+++ b/flake.nix
@@ -81,7 +81,7 @@
           pname = "scanline";
           version = "0.4.0";
           src = pkgs.lib.cleanSource ./.;
-          vendorHash = "sha256-4cZJI0Q1cmMeeBCCUIQFD667Z9Q50cAqNjB+pttJ4ts=";
+          vendorHash = "sha256-1s5fUO5xXY6q0tYBDgxwhhH4oQ5oYsnpnGH/54Eq4Ik=";
 
           ldflags = [
             "-X \"github.com/0skillallluck/scanline/app/dialogs/about.Commit=${

--- a/go.mod
+++ b/go.mod
@@ -3,13 +3,12 @@ module github.com/0skillallluck/scanline
 go 1.26.0
 
 require (
-	codeberg.org/dergs/tonearm v1.4.1-0.20260304095737-2bc41c208498
-	codeberg.org/puregotk/puregotk v0.0.0-20260320050432-5bb8c3359c53
+	codeberg.org/dergs/tonearm v1.4.1-0.20260423094524-7e92b9bac909
+	codeberg.org/puregotk/puregotk v0.0.0-20260420231554-98419d54d2d2
 	github.com/google/uuid v1.6.0
 	github.com/jeandeaual/go-locale v0.0.0-20250612000132-0ef82f21eade
 	github.com/keybase/go-keychain v0.0.1
 	github.com/leonelquinteros/gotext v1.7.2
-	github.com/lescuer97/go-libsecret v0.0.0-20251130160347-067b741bcf5a
 	github.com/yeqown/go-qrcode/v2 v2.2.5
 	github.com/yeqown/go-qrcode/writer/standard v1.3.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,9 @@
-codeberg.org/dergs/tonearm v1.4.1-0.20260304095737-2bc41c208498 h1:AboL9yBPVCXMISsHh+CtQDYvKyoRS+ParsmBvy2Q5w0=
-codeberg.org/dergs/tonearm v1.4.1-0.20260304095737-2bc41c208498/go.mod h1:0tdRotuB0qHS0o4fEHZpyJqHXH3RCfiv2HaZCBSB3e0=
+codeberg.org/dergs/tonearm v1.4.1-0.20260423094524-7e92b9bac909 h1:FcEkczk1EFQ8nJswlz4rzD72UatIfN97Kpp6GbjxeEE=
+codeberg.org/dergs/tonearm v1.4.1-0.20260423094524-7e92b9bac909/go.mod h1:Qi5NGNFaMtp8NWwtGtbCGWLJ3LpvDTWxcv3aC0iEhFI=
 codeberg.org/puregotk/purego v0.0.0-20260224095105-2513c838cb80 h1:y5ZxMLLOjl4xc2tBl02olxZQ06xbbKiR+2ipBfDrVcs=
 codeberg.org/puregotk/purego v0.0.0-20260224095105-2513c838cb80/go.mod h1:hVVM4ddvYRlc3IcK3CXJPlMwd/vaLj7gdDBZ6oPgT8w=
-codeberg.org/puregotk/puregotk v0.0.0-20260320050432-5bb8c3359c53 h1:2djv1s/tkZRjI8DNzA97mfpGR31VJ1da8QHaqecWCDI=
-codeberg.org/puregotk/puregotk v0.0.0-20260320050432-5bb8c3359c53/go.mod h1:Q2E89WEkiGRObalH0QeYJe19f1H+6cn40xavs9+cxdU=
+codeberg.org/puregotk/puregotk v0.0.0-20260420231554-98419d54d2d2 h1:i2Z8LWUE+bunEy9O43+CeQeFj3SvAtkiIzJibDp0XxY=
+codeberg.org/puregotk/puregotk v0.0.0-20260420231554-98419d54d2d2/go.mod h1:KDQjaDscQiL2OiLWuBFBF4l/x/1DW+M0lPcQTa0Id0o=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fogleman/gg v1.3.0 h1:/7zJX8F6AaYQc57WQCyN9cAIz+4bCJGO9B+dyW29am8=
@@ -18,8 +18,6 @@ github.com/keybase/go-keychain v0.0.1 h1:way+bWYa6lDppZoZcgMbYsvC7GxljxrskdNInRt
 github.com/keybase/go-keychain v0.0.1/go.mod h1:PdEILRW3i9D8JcdM+FmY6RwkHGnhHxXwkPPMeUgOK1k=
 github.com/leonelquinteros/gotext v1.7.2 h1:bDPndU8nt+/kRo1m4l/1OXiiy2v7Z7dfPQ9+YP7G1Mc=
 github.com/leonelquinteros/gotext v1.7.2/go.mod h1:9/haCkm5P7Jay1sxKDGJ5WIg4zkz8oZKw4ekNpALob8=
-github.com/lescuer97/go-libsecret v0.0.0-20251130160347-067b741bcf5a h1:0U0890+79rkdjJx4M3+0TGmRhcvRPqUcz4z2DHz3CB4=
-github.com/lescuer97/go-libsecret v0.0.0-20251130160347-067b741bcf5a/go.mod h1:NVIUI2eo6wJGm+999fHgjvc95/u1EfdXnBJ67+S7ai0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
We wanna get rid of more cgo dependencies, updating to the latest Tonearm/Schwifty as well as puregotk allows us to not use CGO for libsecret. Thus removing the need for CGO for Linux builds.