### PR TITLE
Initial MacOS support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ style.css
 style.css.map
 
 scanline
+
+# macOS
+.DS_Store

--- a/app/windows/main_actions.go
+++ b/app/windows/main_actions.go
@@ -13,6 +13,7 @@ import (
 	"github.com/0skillallluck/scanline/app/dialogs/shortcuts"
 	"github.com/0skillallluck/scanline/app/dialogs/sources"
 	"github.com/0skillallluck/scanline/app/router"
+	"github.com/0skillallluck/scanline/internal/accels"
 )
 
 // installAppActions installs actions that live for the entire app lifecycle:
@@ -31,28 +32,28 @@ func (w *Window) installAppActions() {
 		preferences.NewPreferencesDialog().Present(w)
 	}))
 	w.GetApplication().Application.AddAction(preferencesAction)
-	w.GetApplication().SetAccelsForAction("app.preferences", []string{"<Control>comma"})
+	w.GetApplication().SetAccelsForAction("app.preferences", []string{accels.PrimaryMod + "comma"})
 
 	shortcutsAction := gio.NewSimpleAction("shortcuts", nil)
 	shortcutsAction.ConnectActivate(new(func(action gio.SimpleAction, parameter uintptr) {
 		shortcuts.NewShortcutsDialog().Present(w)
 	}))
 	w.GetApplication().Application.AddAction(shortcutsAction)
-	w.GetApplication().SetAccelsForAction("app.shortcuts", []string{"<Control>question"})
+	w.GetApplication().SetAccelsForAction("app.shortcuts", []string{accels.PrimaryMod + "question"})
 
 	quitAction := gio.NewSimpleAction("quit", nil)
 	quitAction.ConnectActivate(new(func(action gio.SimpleAction, parameter uintptr) {
 		w.GetApplication().Quit()
 	}))
 	w.GetApplication().Application.AddAction(quitAction)
-	w.GetApplication().SetAccelsForAction("app.quit", []string{"<Ctrl>q"})
+	w.GetApplication().SetAccelsForAction("app.quit", []string{accels.PrimaryMod + "q"})
 
 	closeAction := gio.NewSimpleAction("close", nil)
 	closeAction.ConnectActivate(new(func(action gio.SimpleAction, parameter uintptr) {
 		w.Close()
 	}))
 	w.AddAction(closeAction)
-	w.GetApplication().SetAccelsForAction("win.close", []string{"<Ctrl>w"})
+	w.GetApplication().SetAccelsForAction("win.close", []string{accels.PrimaryMod + "w"})
 }
 
 // installWindowActions installs actions that only make sense when main content is shown:
@@ -80,7 +81,7 @@ func (w *Window) installWindowActions() {
 		}
 	}))
 	w.AddAction(searchAction)
-	w.GetApplication().SetAccelsForAction("win.search", []string{"<Ctrl>f"})
+	w.GetApplication().SetAccelsForAction("win.search", []string{accels.PrimaryMod + "f"})
 
 	routeMovieAction := gio.NewSimpleAction("route.movie", glib.NewVariantType("s"))
 	routeMovieAction.ConnectActivate(new(func(action gio.SimpleAction, parameter uintptr) {

--- a/flake.nix
+++ b/flake.nix
@@ -30,9 +30,23 @@
             libsecret
           ];
         };
+        # nixpkgs librsvg on Darwin ships a broken loaders.cache (the SVG entry is
+        # missing) and the loader dylib has no LC_RPATH, so dlopen of @rpath/librsvg-2.2.dylib
+        # fails. Provide our own cache; pair with DYLD_FALLBACK_LIBRARY_PATH below.
+        # The trailing blank line is required: gdk-pixbuf parses entries terminated by \n\n.
+        darwinPixbufLoadersCache = pkgs.writeText "scanline-pixbuf-loaders.cache" ''
+          # GdkPixbuf Image Loader Modules file - Scanline devShell override
+          "${pkgs.librsvg.out}/lib/gdk-pixbuf-2.0/2.10.0/loaders/libpixbufloader_svg.dylib"
+          "svg" 6 "gdk-pixbuf" "Scalable Vector Graphics" "LGPL"
+          "image/svg+xml" "image/svg" "image/svg-xml" "image/vnd.adobe.svg+xml" "text/xml-svg" "image/svg+xml-compressed" ""
+          "svg" "svgz" "svg.gz" ""
+          " <svg" "*    " 100
+          " <!DOCTYPE svg" "*             " 100
+
+        '';
       in
       {
-        devShell = pkgs.mkShell {
+        devShell = pkgs.mkShell ({
           PUREGOTK_LIB_FOLDER = "${libraryPath}/lib";
           GSETTINGS_SCHEMA_DIR = "./assets/meta";
           SCANLINE_DEBUG = "1";
@@ -73,11 +87,23 @@
               gst_all_1.gst-libav
               pkg-config # Needed for the first compile with CGO
               sass
+              cacert
             ]
             ++ pkgs.lib.optionals pkgs.stdenv.isLinux [
               flatpak-builder
             ];
-        };
+        } // pkgs.lib.optionalAttrs pkgs.stdenv.isDarwin {
+          # Only set GIO_EXTRA_MODULES on Darwin where the system gio module
+          # path is unavailable. On Linux, leaving this unset lets gio find
+          # the system glib-networking modules required for HTTPS / TLS in
+          # souphttpsrc; setting it (even to empty) breaks network streaming.
+          GIO_EXTRA_MODULES = "${pkgs.glib-networking}/lib/gio/modules";
+          # Override after setup hooks (which propagate librsvg's broken cache).
+          shellHook = ''
+            export GDK_PIXBUF_MODULE_FILE=${darwinPixbufLoadersCache}
+            export DYLD_FALLBACK_LIBRARY_PATH=${libraryPath}/lib
+          '';
+        });
 
         packages.scanline = (pkgs.buildGoModule.override { go = pkgs.go_1_26; }) (finalAttrs: {
           pname = "scanline";

--- a/flake.nix
+++ b/flake.nix
@@ -28,6 +28,7 @@
             gobject-introspection
             librsvg
             libsecret
+            adwaita-icon-theme
           ];
         };
         # nixpkgs librsvg on Darwin ships a broken loaders.cache (the SVG entry is
@@ -99,9 +100,12 @@
           # souphttpsrc; setting it (even to empty) breaks network streaming.
           GIO_EXTRA_MODULES = "${pkgs.glib-networking}/lib/gio/modules";
           # Override after setup hooks (which propagate librsvg's broken cache).
+          # Prepend libraryPath/share so GTK's icon theme loader picks up the
+          # Adwaita icons that ship inside the symlinkJoin on macOS.
           shellHook = ''
             export GDK_PIXBUF_MODULE_FILE=${darwinPixbufLoadersCache}
             export DYLD_FALLBACK_LIBRARY_PATH=${libraryPath}/lib
+            export XDG_DATA_DIRS=${libraryPath}/share''${XDG_DATA_DIRS:+:$XDG_DATA_DIRS}
           '';
         });
 

--- a/internal/accels/accels.go
+++ b/internal/accels/accels.go
@@ -1,0 +1,5 @@
+//go:build !darwin
+
+package accels
+
+const PrimaryMod = "<Primary>"

--- a/internal/accels/accels_darwin.go
+++ b/internal/accels/accels_darwin.go
@@ -1,0 +1,8 @@
+//go:build darwin
+
+package accels
+
+// GTK4 on macOS labels <Primary> as ⌘ in shortcut dialogs but only matches
+// Control at match-time; the Cmd key arrives as <Meta>. Bind <Meta> directly
+// so the accelerator both displays and fires correctly on Cmd.
+const PrimaryMod = "<Meta>"


### PR DESCRIPTION
Add initial minimal support for MacOS, this PR adapts the flake.nix to allow working on and running Scanline on MacOS.

Additionally it fixes the icons missing on MacOS aswell as adjusting the keyboard shortcuts to match MacOS better.